### PR TITLE
added log event message to the event data payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Log.ForContext("EventPropertyName", "myCustomType").Information("{@OtherData}", 
 
 Specify the Serilog logging level. Default is `LogEventLevel.Information`
 
+### Helper Extensions
+
+The sink adds additional extension methods to `ILogger` which can help simplify your Event Grid logging code:
+
+```csharp
+using Serilog.Sinks.EventGrid
+```
+
+```csharp
+// type, subject, and information event message with properties
+Log.EventGrid("myEventTypeName", "myEventSubjectName", "This is my Event {@MyContext}", myContext);
+// type and information event message with properties
+Log.EventGrid("myEventTypeName", "This is my Event {@MyContext}", myContext);
+// type and information event message
+Log.EventGrid("myEventTypeName", "This is my Event");
+```
+
 ### Custom Attributes
 
 As an alternative to specifying the subject and type through log configuration or properties, you can decorate your code at design time with the `[EventGridSubject]` and `[EventGridType]` Attributes. Any method or class is supported, using one or both on each. The Serilog log event called within the context of a method or class decorated with either attribute, will use those values when submitting the event. The first ones closest to the log event call in the stack, win.

--- a/src/Serilog.Sinks.EventGrid/LoggerEventGridExtensions.cs
+++ b/src/Serilog.Sinks.EventGrid/LoggerEventGridExtensions.cs
@@ -1,0 +1,31 @@
+﻿namespace Serilog.Sinks.EventGrid
+{
+  public static class LoggerEventGridExtensions
+  {
+    /// <summary>Information log event helper for EventGrid sink</summary>
+    /// <param name="logger">The Serilog ILogger</param>
+    /// <param name="eventType">The event type sent to EventGrid Grid</param>
+    /// <param name="subject">The event subject sent to EventGrid Grid</param>
+    /// <param name="messageTemplate">The Serilog logger message template</param>
+    /// <param name="props">The values references in the templace to be added to the EventGrid Grid data payload</param>
+    public static void EventGrid(this ILogger logger, string eventType, string subject, string messageTemplate, params object[] props)
+    {
+      if (!string.IsNullOrEmpty(subject))
+        logger = logger.ForContext("EventSubject", subject);
+      if (!string.IsNullOrEmpty(eventType))
+        logger = logger.ForContext("EventType", eventType);
+      if (!string.IsNullOrEmpty(messageTemplate))
+        logger.Information(messageTemplate, props);
+    }
+
+    public static void EventGrid(this ILogger logger, string eventType, string messageTemplate, params object[] props)
+    {
+      logger.EventGrid(eventType, null, messageTemplate, props); 
+    }
+
+    public static void EventGrid(this ILogger logger, string eventType, string messageTemplate)
+    {
+      logger.EventGrid(eventType, null, messageTemplate, null);
+    }
+  }
+}

--- a/src/Serilog.Sinks.EventGrid/Serilog.Sinks.EventGrid.csproj
+++ b/src/Serilog.Sinks.EventGrid/Serilog.Sinks.EventGrid.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/Authenticom/serilog-sinks-eventgrid</RepositoryUrl>
     <PackageTags>serilog events eventgrid</PackageTags>
     <Copyright>Copyright © Chris Kirby 2017</Copyright>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Serilog.Sinks.EventGrid/Sinks/EventGrid/EventGridSink.cs
+++ b/src/Serilog.Sinks.EventGrid/Sinks/EventGrid/EventGridSink.cs
@@ -61,6 +61,7 @@ namespace Serilog.Sinks.EventGrid
         GetEventInfoFromAttribute(customEvent);
 
       // clean up the payload
+      props.Add("LogMessage", logEvent.MessageTemplate.Text);
       customEvent.Data = props.Where(p => p.Key != _customSubjectPropertyName && p.Key != _customTypePropertyName);
 
       // finally, we have what we need post the event


### PR DESCRIPTION
Fixed
* The log event message template text will now show as a property in the data object of the event

New
* ILogger extension methods to simply passing event type and subject with each log event