### PR TITLE
split extension method overloads into separate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ using Serilog.Sinks.EventGrid
 
 ```csharp
 // type, subject, and information event message with properties
-Log.EventGrid("myEventTypeName", "myEventSubjectName", "This is my Event {@MyContext}", myContext);
-// type and information event message with properties
-Log.EventGrid("myEventTypeName", "This is my Event {@MyContext}", myContext);
-// type and information event message
-Log.EventGrid("myEventTypeName", "This is my Event");
+Log.Event("myEventTypeName", "myEventSubjectName", "This is my Event {@MyContext}", myContext);
+// type or subject with information event message and properties
+Log.EventType("myEventTypeName", "This is my Event {@MyContext}", myContext);
+Log.EventSubject("myEventSubjectName", "This is my Event {@MyContext}", myContext);
+// type or subject with information event message
+Log.EventType("myEventTypeName", "This is my Event");
+Log.EventSubject("myEventSubjectName", "This is my Event");
 ```
 
 ### Custom Attributes

--- a/src/Serilog.Sinks.EventGrid/LoggerEventGridExtensions.cs
+++ b/src/Serilog.Sinks.EventGrid/LoggerEventGridExtensions.cs
@@ -8,7 +8,7 @@
     /// <param name="subject">The event subject sent to EventGrid Grid</param>
     /// <param name="messageTemplate">The Serilog logger message template</param>
     /// <param name="props">The values references in the templace to be added to the EventGrid Grid data payload</param>
-    public static void EventGrid(this ILogger logger, string eventType, string subject, string messageTemplate, params object[] props)
+    public static void Event(this ILogger logger, string eventType, string subject, string messageTemplate, params object[] props)
     {
       if (!string.IsNullOrEmpty(subject))
         logger = logger.ForContext("EventSubject", subject);
@@ -18,14 +18,42 @@
         logger.Information(messageTemplate, props);
     }
 
-    public static void EventGrid(this ILogger logger, string eventType, string messageTemplate, params object[] props)
+    /// <summary>Log to Event Grid with custom subject and message template w/ custom args</summary>
+    /// <param name="logger">The Serilog ILogger</param>
+    /// <param name="subject">The event subject sent to EventGrid Grid</param>
+    /// <param name="messageTemplate">The Serilog logger message template</param>
+    /// <param name="props">The values references in the templace to be added to the EventGrid Grid data payload</param>
+    public static void EventSubject(this ILogger logger, string subject, string messageTemplate, params object[] props)
     {
-      logger.EventGrid(eventType, null, messageTemplate, props); 
+      logger.Event(null, subject, messageTemplate, props);
     }
 
-    public static void EventGrid(this ILogger logger, string eventType, string messageTemplate)
+    /// <summary>Log to Event Grid with custom type and message template</summary>
+    /// <param name="logger">The Serilog ILogger</param>
+    /// <param name="subject">The event subject sent to EventGrid Grid</param>
+    /// <param name="messageTemplate">The Serilog logger message template</param>
+    public static void EventSubject(this ILogger logger, string subject, string messageTemplate)
     {
-      logger.EventGrid(eventType, null, messageTemplate, null);
+      logger.Event(null, subject, messageTemplate, null);
+    }
+
+    /// <summary>Log to Event Grid with custom type and message template w/ custom args</summary>
+    /// <param name="logger">The Serilog ILogger</param>
+    /// <param name="eventType">The event type sent to EventGrid Grid</param>
+    /// <param name="messageTemplate">The Serilog logger message template</param>
+    /// <param name="props">The values references in the templace to be added to the EventGrid Grid data payload</param>
+    public static void EventType(this ILogger logger, string eventType, string messageTemplate, params object[] props)
+    {
+      logger.Event(eventType, null, messageTemplate, props); 
+    }
+
+    /// <summary>Log to Event Grid with custom type and message template</summary>
+    /// <param name="logger">The Serilog ILogger</param>
+    /// <param name="eventType">The event type sent to EventGrid Grid</param>
+    /// <param name="messageTemplate">The Serilog logger message template</param>
+    public static void EventType(this ILogger logger, string eventType, string messageTemplate)
+    {
+      logger.Event(eventType, null, messageTemplate, null);
     }
   }
 }

--- a/src/Serilog.Sinks.EventGrid/Serilog.Sinks.EventGrid.csproj
+++ b/src/Serilog.Sinks.EventGrid/Serilog.Sinks.EventGrid.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/Authenticom/serilog-sinks-eventgrid</RepositoryUrl>
     <PackageTags>serilog events eventgrid</PackageTags>
     <Copyright>Copyright © Chris Kirby 2017</Copyright>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">


### PR DESCRIPTION
- when just specifying type or subject by themselves, there are new separate extension methods to avoid signature matching issues when params are strings
- full event extension method name changed to Event from EventGrid
- updated documentation and package version

fixes #9