### PR TITLE
Resolves issue with Event extension methods where no event is sent when a log event message is not specified

### DIFF
--- a/src/Serilog.Sinks.EventGrid/LoggerEventGridExtensions.cs
+++ b/src/Serilog.Sinks.EventGrid/LoggerEventGridExtensions.cs
@@ -8,14 +8,15 @@
     /// <param name="subject">The event subject sent to EventGrid Grid</param>
     /// <param name="messageTemplate">The Serilog logger message template</param>
     /// <param name="props">The values references in the templace to be added to the EventGrid Grid data payload</param>
-    public static void Event(this ILogger logger, string eventType, string subject, string messageTemplate, params object[] props)
+    public static void Event(this ILogger logger, string eventType, string subject, string messageTemplate = "", params object[] props)
     {
       if (!string.IsNullOrEmpty(subject))
         logger = logger.ForContext("EventSubject", subject);
+
       if (!string.IsNullOrEmpty(eventType))
         logger = logger.ForContext("EventType", eventType);
-      if (!string.IsNullOrEmpty(messageTemplate))
-        logger.Information(messageTemplate, props);
+
+      logger.Information(messageTemplate, props);
     }
 
     /// <summary>Log to Event Grid with custom subject and message template w/ custom args</summary>
@@ -44,7 +45,7 @@
     /// <param name="props">The values references in the templace to be added to the EventGrid Grid data payload</param>
     public static void EventType(this ILogger logger, string eventType, string messageTemplate, params object[] props)
     {
-      logger.Event(eventType, null, messageTemplate, props); 
+      logger.Event(eventType, null, messageTemplate, props);
     }
 
     /// <summary>Log to Event Grid with custom type and message template</summary>

--- a/src/Serilog.Sinks.EventGrid/Serilog.Sinks.EventGrid.csproj
+++ b/src/Serilog.Sinks.EventGrid/Serilog.Sinks.EventGrid.csproj
@@ -14,9 +14,9 @@
     <RepositoryUrl>https://github.com/Authenticom/serilog-sinks-eventgrid</RepositoryUrl>
     <PackageTags>serilog sink events eventgrid azure</PackageTags>
     <Copyright>Copyright © Chris Kirby 2017</Copyright>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.Net.Http">
       <Version>2.2.29</Version>
@@ -24,10 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="newtonsoft.json" Version="10.0.3" />
-    <PackageReference Include="serilog" Version="2.5.0" />
-    <PackageReference Include="serilog.sinks.periodicbatching" Version="2.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.EventGrid/Sinks/EventGrid/EventGridSink.cs
+++ b/src/Serilog.Sinks.EventGrid/Sinks/EventGrid/EventGridSink.cs
@@ -14,12 +14,12 @@ namespace Serilog.Sinks.EventGrid
     public const int DefaultBatchPostingLimit = 10;
     public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(5);
 
-    public EventGridSink(IFormatProvider formatProvider, 
-      string key, 
-      Uri topicUri, 
+    public EventGridSink(IFormatProvider formatProvider,
+      string key,
+      Uri topicUri,
       string customEventSubject,
-      string customEventType, 
-      CustomEventRequestAuth customEventRequestAuth, 
+      string customEventType,
+      CustomEventRequestAuth customEventRequestAuth,
       string customSubjectPropertyName,
       string customTypePropertyName,
       int batchSizeLimit,


### PR DESCRIPTION
* When an event message template is not specified, it's defaulted to `""`